### PR TITLE
Fix Logger provider Configuration

### DIFF
--- a/examples/ActivityLogger/Program.cs
+++ b/examples/ActivityLogger/Program.cs
@@ -31,7 +31,7 @@ namespace ActivityLogger
 
         private static IHost CreateHost() =>
             new HostBuilder()
-                .UseEnvironment(Environment.GetEnvironmentVariable("App_Environment"))
+                .UseEnvironment(Environment.GetEnvironmentVariable("App_Environment") ?? "Production")
                 .ConfigureAppConfiguration(builder => builder
                     .AddJsonFile("appsettings.json", false, true)
                     .AddJsonFile(
@@ -41,8 +41,8 @@ namespace ActivityLogger
                 .ConfigureLogging((hostingContext, builder) =>
                     builder.AddServiceLogging(hostingContext.Configuration, new LoggerOptions
                     {
-                        UseActivityLogger = true,
-                        UseApplicationInsights = false
+                        LogActivityDataToCosmos = false,
+                        LogTelemetryDataToApplicationInsights = false
                     }))
                 .Build();
 

--- a/examples/ActivityLogger/Program.cs
+++ b/examples/ActivityLogger/Program.cs
@@ -41,8 +41,8 @@ namespace ActivityLogger
                 .ConfigureLogging((hostingContext, builder) =>
                     builder.AddServiceLogging(hostingContext.Configuration, new LoggerOptions
                     {
-                        LogActivityDataToCosmos = false,
-                        LogTelemetryDataToApplicationInsights = false
+                        SendLogActivityDataToCosmos = false,
+                        SendLogDataToApplicationInsights = false
                     }))
                 .Build();
 

--- a/src/SoCreate.Extensions.Logging/ActivityLogger/ActivityLogger.cs
+++ b/src/SoCreate.Extensions.Logging/ActivityLogger/ActivityLogger.cs
@@ -39,7 +39,7 @@ namespace SoCreate.Extensions.Logging.ActivityLogger
                 new PropertyEnricher("Version", _version),
                 new PropertyEnricher("KeySet", keySet.ToDictionary()),
                 new PropertyEnricher("ActionType", actionType.ToString(), true),
-                new PropertyEnricher(ActivityLoggerLogConfigurationAdapter.LogTypeKey, _activityLogType)
+                new PropertyEnricher(CosmosActivityLoggerLogConfigurationAdapter.LogTypeKey, _activityLogType)
             };
             if (additionalData != null)
             {

--- a/src/SoCreate.Extensions.Logging/CosmosActivityLoggerLogConfigurationAdapter.cs
+++ b/src/SoCreate.Extensions.Logging/CosmosActivityLoggerLogConfigurationAdapter.cs
@@ -8,13 +8,13 @@ using SoCreate.Extensions.Logging.ActivityLogger;
 
 namespace SoCreate.Extensions.Logging
 {
-    class ActivityLoggerLogConfigurationAdapter
+    class CosmosActivityLoggerLogConfigurationAdapter
     {
         public const string LogTypeKey = "LogType";
         private readonly IConfiguration _configuration;
         private readonly IHostEnvironment _env;
 
-        public ActivityLoggerLogConfigurationAdapter(IConfiguration configuration, IHostEnvironment environment)
+        public CosmosActivityLoggerLogConfigurationAdapter(IConfiguration configuration, IHostEnvironment environment)
         {
             _configuration = configuration;
             _env = environment;

--- a/src/SoCreate.Extensions.Logging/LoggerOptions.cs
+++ b/src/SoCreate.Extensions.Logging/LoggerOptions.cs
@@ -6,12 +6,12 @@ namespace SoCreate.Extensions.Logging
     {
         public LoggerOptions()
         {
-            LogTelemetryDataToApplicationInsights = true;
-            LogActivityDataToCosmos = false;
+            SendLogDataToApplicationInsights = true;
+            SendLogActivityDataToCosmos = false;
         }
 
-        public bool LogTelemetryDataToApplicationInsights { get; set; }
-        public bool LogActivityDataToCosmos { get; set; }
+        public bool SendLogDataToApplicationInsights { get; set; }
+        public bool SendLogActivityDataToCosmos { get; set; }
         public Func<int>? GetUserId { get; set; }
     }
 }

--- a/src/SoCreate.Extensions.Logging/LoggerOptions.cs
+++ b/src/SoCreate.Extensions.Logging/LoggerOptions.cs
@@ -6,12 +6,12 @@ namespace SoCreate.Extensions.Logging
     {
         public LoggerOptions()
         {
-            UseApplicationInsights = true;
-            UseActivityLogger = false;
+            LogTelemetryDataToApplicationInsights = true;
+            LogActivityDataToCosmos = false;
         }
 
-        public bool UseApplicationInsights { get; set; }
-        public bool UseActivityLogger { get; set; }
+        public bool LogTelemetryDataToApplicationInsights { get; set; }
+        public bool LogActivityDataToCosmos { get; set; }
         public Func<int>? GetUserId { get; set; }
     }
 }

--- a/src/SoCreate.Extensions.Logging/LoggingBuilderExtensions.cs
+++ b/src/SoCreate.Extensions.Logging/LoggingBuilderExtensions.cs
@@ -50,13 +50,13 @@ namespace SoCreate.Extensions.Logging
         {
             var loggerConfig = serviceProvider.GetRequiredService<LoggerConfiguration>();
 
-            if (options.LogTelemetryDataToApplicationInsights)
+            if (options.SendLogDataToApplicationInsights)
             {
                 serviceProvider.GetRequiredService<ApplicationInsightsLoggerLogConfigurationAdapter>()
                     .ApplyConfiguration(loggerConfig, options);
             }
 
-            if (options.LogActivityDataToCosmos)
+            if (options.SendLogActivityDataToCosmos)
             {
                 serviceProvider.GetRequiredService<CosmosActivityLoggerLogConfigurationAdapter>()
                     .ApplyConfiguration(loggerConfig);

--- a/src/SoCreate.Extensions.Logging/SoCreate.Extensions.Logging.csproj
+++ b/src/SoCreate.Extensions.Logging/SoCreate.Extensions.Logging.csproj
@@ -11,7 +11,7 @@
     <PackageTags>Logging</PackageTags>
     <RepositoryType>git</RepositoryType>
     <Copyright>© SoCreate. All rights reserved.</Copyright>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
- LoggerOptions fields have been renamed.
- ApplicationInsights logger and activity logger cannot be toggled on or off. They are always registered to the DI container.
- Logging activity data to cosmos or logging telemetry data to application insights can be toggled on or off.